### PR TITLE
Add .spec.forceRun field to api and crd

### DIFF
--- a/api/v1/roleupdater_types.go
+++ b/api/v1/roleupdater_types.go
@@ -12,6 +12,7 @@ type ConfigMapRef struct {
 
 type RoleUpdaterSpec struct {
 	ConfigMapRef ConfigMapRef `json:"configMapRef"`
+	ForceRun     bool         `json:"forceRun,omitempty"`
 }
 
 type RoleUpdaterStatus struct {

--- a/config/crd/bases/role.updater.compute.io_roleupdaters.yaml
+++ b/config/crd/bases/role.updater.compute.io_roleupdaters.yaml
@@ -56,6 +56,11 @@ spec:
                 required:
                 - name
                 type: object
+              forceRun:
+                description: |-
+                  ForceRun is an optional boolean field that, when set to true, forces the operator to run the script inside the configMap
+                  specified in .spec.configMapRef during the next reconciliation loop, regardless of whether the clusterVersion changed or not.
+                type: boolean
             required:
             - configMapRef
             type: object


### PR DESCRIPTION
The API configuration and the crd description were missing the `.spec.forceRun` field, this PR adds them.