### PR TITLE
Updated the types files with comments to add description to the crd.

### DIFF
--- a/api/v1/roleupdater_types.go
+++ b/api/v1/roleupdater_types.go
@@ -5,22 +5,47 @@ import (
 )
 
 type ConfigMapRef struct {
+
+	// Name is the name of the configMap that contains the script to be run
+	// when the clusterVersion changes.
 	Name string `json:"name"`
+
 	// +optional
+	// Namespace is the name of the configMap that contains the script to be run when the clusterVersion changes.
+	// If left empty, it will default to the namespace of the RoleUpdater.
 	Namespace string `json:"namespace,omitempty"`
 }
 
+// Spec is a list of the desired state of the RoleUpdater. It has a single field, configMapRef, which is a reference to a configMap
+// in the cluster that contains the script that will be run every single clusterVersion change.
 type RoleUpdaterSpec struct {
+
+	// ConfigMapRef is a field that contains the name and the namespace of the configMap that contains the script to be run
+	// when the clusterVersion changes.
 	ConfigMapRef ConfigMapRef `json:"configMapRef"`
-	ForceRun     bool         `json:"forceRun,omitempty"`
+
+	// ForceRun is an optional boolean field that, when set to true, forces the operator to run the script inside the configMap
+	// specified in .spec.configMapRef during the next reconciliation loop, regardless of whether the clusterVersion changed or not.
+	ForceRun bool `json:"forceRun,omitempty"`
 }
 
+// Status defines the observed state of RoleUpdater.
 type RoleUpdaterStatus struct {
-	LastCheckTime    string `json:"lastCheckTime,omitempty"`
-	ClusterVersion   string `json:"clusterVersion,omitempty"`
-	Status           string `json:"status,omitempty"`
-	Message          string `json:"message,omitempty"`
-	ConfigMapPresent bool   `json:"configMapPresent"`
+
+	// The last time the operator checked the clusterVersion resource.
+	LastCheckTime string `json:"lastCheckTime,omitempty"`
+
+	// The current clusterVersion fetched from the ClusterVersion resource.
+	ClusterVersion string `json:"clusterVersion,omitempty"`
+
+	// A short string value indicating the status of the RoleUpdater.
+	Status string `json:"status,omitempty"`
+
+	// An informative message indicating the status of the RoleUpdater.
+	Message string `json:"message,omitempty"`
+
+	// A boolean value that indicates whether the configMap specified in spec.configMapRef is present in the cluster.
+	ConfigMapPresent bool `json:"configMapPresent"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/role.updater.compute.io_roleupdaters.yaml
+++ b/config/crd/bases/role.updater.compute.io_roleupdaters.yaml
@@ -37,7 +37,7 @@ spec:
             type: object
           spec:
             description: |-
-              Spc is a list of the desired state of the RoleUpdater. It has a single field, configMapRef, which is a reference to a configMap
+              Spec is a list of the desired state of the RoleUpdater. It has a single field, configMapRef, which is a reference to a configMap
               in the cluster that contains the script that will be run every single clusterVersion change.
             properties:
               configMapRef:
@@ -46,7 +46,9 @@ spec:
                   when the clusterVersion changes.
                 properties:
                   name:
-                    description: Name is the name of the configMap that contains the script to be run when the clusterVersion changes.
+                    description: |-
+                      Name is the name of the configMap that contains the script to be run
+                      when the clusterVersion changes.
                     type: string
                   namespace:
                     description: |-
@@ -68,13 +70,16 @@ spec:
             description: Status defines the observed state of RoleUpdater.
             properties:
               clusterVersion:
-                description: The current clusterVersion fetched from the ClusterVersion resource. 
+                description: The current clusterVersion fetched from the ClusterVersion
+                  resource.
                 type: string
               configMapPresent:
-                description: A boolean value that indicates whether the configMap specified in spec.configMapRef is present in the cluster.
+                description: A boolean value that indicates whether the configMap
+                  specified in spec.configMapRef is present in the cluster.
                 type: boolean
               lastCheckTime:
-                description: The last time the operator checked the clusterVersion resource.
+                description: The last time the operator checked the clusterVersion
+                  resource.
                 type: string
               message:
                 description: An informative message indicating the status of the RoleUpdater.


### PR DESCRIPTION
The previous PR introduced the change in the `crd` via the `crd` itself at `/config/crd/bases`, to make it persistent, I added comments to the types file.